### PR TITLE
chore: prove to Algolia DocSearch that this domain may be crawled

### DIFF
--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,1 @@
+# Algolia-Crawler-Verif: 008434AFD9BDCD10


### PR DESCRIPTION
A step in trying out Docsearch. It's free for open-source: https://docsearch.algolia.com/docs/docsearch-program#how-much-does-it-cost

This PR follows instructions here: https://www.algolia.com/doc/tools/crawler/getting-started/create-crawler/#robotstxt

part of #4 